### PR TITLE
Adding translations feature to AMO

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "AMO Review Helper",
   "name": "amoqueue",
-  "version": "5.5.3",
+  "version": "5.6.2",
   "description": "Enhancements to the AMO review experience",
   "main": "shim/background.js",
   "author": "Philipp Kewisch",

--- a/webextension/background/translation.js
+++ b/webextension/background/translation.js
@@ -1,0 +1,35 @@
+var authToken;
+var tokenttl = 1000*60*10;
+var tokenTimeout = 0;
+
+sdk.runtime.onMessage.addListener((data, sender, sendReply) => {
+  if (data.action !== "translate") {
+    return;
+  }
+
+  chrome.storage.local.get({ "translation-secret-key": "" }, (prefs) => {
+    if (!prefs["translation-secret-key"]) {
+      sendReply({ error: "Secret key not set" });
+      return;
+    }
+
+    if (tokenTimeout < Date.now()) {
+      var reqHeaders = new Headers({ "Ocp-Apim-Subscription-Key": prefs["translation-secret-key"] });
+      fetch("https://api.cognitive.microsoft.com/sts/v1.0/issueToken", { method: "POST", headers: reqHeaders }).then((resp) => resp.text()).then((response) => {
+        authToken = response;
+        tokenTimeout = Date.now() + tokenttl;
+        translate(data.text, sendReply);
+      });
+    } else {
+      translate(data.text, sendReply);
+    }
+  });
+});
+
+function translate(text, callback) {
+  var reqHeaders = new Headers({ Authorization: "Bearer " + authToken });
+  fetch("https://api.microsofttranslator.com/V2/Http.svc/Translate?text=" + encodeURIComponent(text) + "&to=en", { method: "GET", headers: reqHeaders }).then((resp) => resp.text()).then((response) => {
+    var translatedText = response;
+    callback({ text: translatedText.replace(/<[^>]*>/g, "") });
+  });
+}

--- a/webextension/content/translate/moderatedreviews.js
+++ b/webextension/content/translate/moderatedreviews.js
@@ -1,0 +1,41 @@
+window.addEventListener("load", () => {
+  // Moderated reviews
+  $(".review-flagged p:not(.description)").each(function() {
+    var reviewNode = $(this);
+    reviewNode.append(
+      $("<a />").text(" translate").click(function() {
+        translate(reviewNode.next(), $(this));
+      })
+    );
+  });
+
+  // Listed/Unlisted reviews
+  $("#addon-summary").prepend(
+    $("<a />").text("(Translate summary)").click(function() {
+      translate($("#addon-summary p:not(.addon-rating)"), $(this));
+    })
+  );
+
+  $(".article").prepend(
+    $("<a />").text("(Translate description)").click(function() {
+      translate($(".article p"), $(this));
+    })
+  );
+
+  function translate(textNode, clickedNode) {
+    var sending = browser.runtime.sendMessage({
+      action: "translate",
+      text: textNode.text(),
+      from: "translate"
+    });
+
+    sending.then((data) => {
+      if (data.error) {
+        clickedNode.text("Error : Key not set. See addon's options page.");
+      } else {
+        clickedNode.remove();
+        textNode.text(data.text);
+      }
+    });
+  }
+});

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "AMO Review Helper",
   "short_name": "AMO Helper",
-  "version": "5.5.3",
+  "version": "5.6.2",
   "icons": {
     "16": "images/addon.svg",
     "32": "images/addon.svg",
@@ -22,7 +22,9 @@
     "webRequestBlocking",
 
     "https://addons.mozilla.org/*",
-    "https://addons.cdn.mozilla.net/*"
+    "https://addons.cdn.mozilla.net/*",
+    "https://api.cognitive.microsoft.com/*",
+    "https://api.microsofttranslator.com/*"
   ],
 
   "options_ui": {
@@ -52,7 +54,8 @@
       "background/tinderbar.js",
       "background/queueinfo.js",
       "background/omnibox.js",
-      "background/browseraction.js"
+      "background/browseraction.js",
+      "background/translation.js"
     ]
   },
 
@@ -81,6 +84,13 @@
       ],
       "js": ["content/tabclose/find_addonid.js"],
       "run_at": "document_end"
+    },{
+      "matches": [ "https://addons.mozilla.org/en-US/editors/queue/reviews*" ],
+      "js": [
+        "libs/jquery-3.1.1.min.js",
+        "content/translate/moderatedreviews.js"
+      ],
+      "run_at": "document_start"
     },{
       "matches": [ "https://addons.mozilla.org/en-US/editors/queue/*" ],
       "js": ["content/tabclose/queue.js"],
@@ -199,6 +209,17 @@
       ],
       "js": [ "content/tinderbar/review.js" ],
       "css": [ "content/tinderbar/review.css" ],
+      "run_at": "document_end"
+    },{
+      "matches": [
+        "https://addons.mozilla.org/en-US/editors/review/*",
+        "https://addons.mozilla.org/en-US/editors/review-listed/*",
+        "https://addons.mozilla.org/en-US/editors/review-unlisted/*"
+      ],
+      "js": [ 
+        "libs/jquery-3.1.1.min.js",
+        "content/translate/moderatedreviews.js" 
+      ],
       "run_at": "document_end"
     }
   ]

--- a/webextension/options/options.html
+++ b/webextension/options/options.html
@@ -113,6 +113,14 @@
     </label>
   </section>
 
+  <section id="translation-section">
+    <h1>Translation</h1>
+    <label>
+      Microsoft Azure translator text API secret key :
+      <input type="text" id="translation-secret-key">
+    </label>
+  </section>
+
   <section id="tinderbar-section" class="admin-only">
     <h1>Quick Review</h1>
     <label>

--- a/webextension/options/options.js
+++ b/webextension/options/options.js
@@ -46,6 +46,7 @@ function restore_options() {
     "reviewinfo-show-validator": false,
     "reviewtimer-display": true,
     "reviewtimer-notify-interval": 10,
+    "translation-secret-key": "",
     "tinderbar-show": false,
     "tinderbar-approve-text": "Thank you for your contribution. This version has been approved using a streamlined review process.",
     "tinderbar-preload-tabs": 3
@@ -66,6 +67,7 @@ function restore_options() {
     document.getElementById("reviewinfo-show-validator").checked = prefs["reviewinfo-show-validator"];
     document.getElementById("reviewtimer-display").checked = prefs["reviewtimer-display"];
     document.getElementById("reviewtimer-notify-interval").value = prefs["reviewtimer-notify-interval"];
+    document.getElementById("translation-secret-key").value = prefs["translation-secret-key"];
     document.getElementById("tinderbar-show").checked = prefs["tinderbar-show"];
     document.getElementById("tinderbar-approve-text").value = prefs["tinderbar-approve-text"];
     document.getElementById("tinderbar-preload-tabs").value = prefs["tinderbar-preload-tabs"];


### PR DESCRIPTION
This change-set add back the feature we lost with https://github.com/mozilla/addons-server/issues/4990

It also add translation features directly inside the listing page for summaries and descriptions.

To be able to test this out, I can provide you a key. Just ask me privately by email or IRC.