### PR TITLE
Mass replace /editors/ to /reviewers/

### DIFF
--- a/background/browseraction.js
+++ b/background/browseraction.js
@@ -23,7 +23,7 @@ function parseQueueNumbers(doc) {
 
 async function updateQueueNumbers() {
   let instance = await getStoragePreference("instance");
-  let url = `https://${instance}/en-US/editors/queue/auto_approved`;
+  let url = `https://${instance}/en-US/reviewers/queue/auto_approved`;
   let text = await fetch(url, { mode: "cors", credentials: "include" }).then(resp => resp.text());
   let parser = new DOMParser();
   let doc = parser.parseFromString(text, "text/html");

--- a/background/omnibox.js
+++ b/background/omnibox.js
@@ -7,7 +7,7 @@ const allSuggestions = {
   "": {
     content: "{keyword}",
     description: "Editor Review for {keyword}",
-    url: "https://{instance}/editors/review/{keyword}"
+    url: "https://{instance}/reviewers/review/{keyword}"
   },
   "addon": {
     content: "addon {keyword}",

--- a/common/constants.js
+++ b/common/constants.js
@@ -10,7 +10,7 @@
  * AMO_PRIVACY_PAGES, AMO_EULA_PAGES, AMO_QUEUE_PATTERNS, AMO_REVIEW_PATTERNS,
  * ADDON_LINK_PATTERNS */
 
-const REVIEW_URL = "https://reviewers.{instance}/editors/review/{addon}";
+const REVIEW_URL = "https://reviewers.{instance}/reviewers/review/{addon}";
 const ADMIN_URL = "https://{instance}/admin/addon/manage/{addon}";
 const LISTING_URL = "https://{instance}/addon/{addon}";
 const MANAGE_URL = "https://{instance}/developers/addon/{addon}/edit";
@@ -23,9 +23,9 @@ const FILEBROWSER_RE = /https:\/\/reviewers\.(addons\.mozilla|addons\.allizom|ad
 const USER_RE = /https:\/\/(addons\.mozilla|addons\.allizom|addons-dev\.allizom)\.org\/([^/]+)\/firefox\/user\/([^#/]*)/;
 
 const REVIEW_PATTERNS = [
-  "https://reviewers.addons.mozilla.org/*/editors/review/{addon}",
-  "https://reviewers.addons.allizom.org/*/editors/review/{addon}",
-  "https://reviewers.addons-dev.allizom.org/*/editors/review/{addon}"
+  "https://reviewers.addons.mozilla.org/*/reviewers/review/{addon}",
+  "https://reviewers.addons.allizom.org/*/reviewers/review/{addon}",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/review/{addon}"
 ];
 
 const FILEBROWSER_PATTERNS = [
@@ -67,9 +67,9 @@ const AMO_HOSTS = [
 ];
 
 const AMO_EDITORS_PATTERNS = [
-  "https://reviewers.addons.mozilla.org/*/editors/*",
-  "https://reviewers.addons.allizom.org/*/editors/*",
-  "https://reviewers.addons-dev.allizom.org/*/editors/*"
+  "https://reviewers.addons.mozilla.org/*/reviewers/*",
+  "https://reviewers.addons.allizom.org/*/reviewers/*",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/*"
 ];
 
 const AMO_PRIVACY_PAGES = [
@@ -85,35 +85,35 @@ const AMO_EULA_PAGES = [
 ];
 
 const AMO_QUEUE_PATTERNS = [
-  "https://reviewers.addons.mozilla.org/*/editors/queue/*",
-  "https://reviewers.addons.allizom.org/*/editors/queue/*",
-  "https://reviewers.addons-dev.allizom.org/*/editors/queue/*"
+  "https://reviewers.addons.mozilla.org/*/reviewers/queue/*",
+  "https://reviewers.addons.allizom.org/*/reviewers/queue/*",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/queue/*"
 ];
 
 const AMO_REVIEW_PATTERNS = [
-  "https://reviewers.addons.mozilla.org/*/editors/review/{slug}",
-  "https://reviewers.addons.allizom.org/*/editors/review/{slug}",
-  "https://reviewers.addons-dev.allizom.org/*/editors/review/{slug}"
+  "https://reviewers.addons.mozilla.org/*/reviewers/review/{slug}",
+  "https://reviewers.addons.allizom.org/*/reviewers/review/{slug}",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/review/{slug}"
 ];
 
 const ADDON_LINK_PATTERNS = [
-  "https://reviewers.addons.mozilla.org/*/editors/review/*",
-  "https://reviewers.addons.mozilla.org/*/editors/review-listed/*",
-  "https://reviewers.addons.mozilla.org/*/editors/review-unlisted/*",
+  "https://reviewers.addons.mozilla.org/*/reviewers/review/*",
+  "https://reviewers.addons.mozilla.org/*/reviewers/review-listed/*",
+  "https://reviewers.addons.mozilla.org/*/reviewers/review-unlisted/*",
   "https://addons.mozilla.org/*/admin/manage/*",
   "https://addons.mozilla.org/*/*/addon/*", /* catches listing and manage url */
   "https://addons.mozilla.org/*/developers/feed/*",
 
-  "https://reviewers.addons.allizom.org/*/editors/review/*",
-  "https://reviewers.addons.allizom.org/*/editors/review-listed/*",
-  "https://reviewers.addons.allizom.org/*/editors/review-unlisted/*",
+  "https://reviewers.addons.allizom.org/*/reviewers/review/*",
+  "https://reviewers.addons.allizom.org/*/reviewers/review-listed/*",
+  "https://reviewers.addons.allizom.org/*/reviewers/review-unlisted/*",
   "https://addons.allizom.org/*/admin/manage/*",
   "https://addons.allizom.org/*/*/addon/*", /* catches listing and manage url */
   "https://addons.allizom.org/*/developers/feed/*",
 
-  "https://reviewers.addons-dev.allizom.org/*/editors/review/*",
-  "https://reviewers.addons-dev.allizom.org/*/editors/review-listed/*",
-  "https://reviewers.addons-dev.allizom.org/*/editors/review-unlisted/*",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/review/*",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/review-listed/*",
+  "https://reviewers.addons-dev.allizom.org/*/reviewers/review-unlisted/*",
   "https://addons-dev.allizom.org/*/admin/manage/*",
   "https://addons-dev.allizom.org/*/*/addon/*", /* catches listing and manage url */
   "https://addons-dev.allizom.org/*/developers/feed/*",

--- a/content/browseraction/popup.html
+++ b/content/browseraction/popup.html
@@ -60,12 +60,12 @@
   </head>
   <body>
     <ul id="menu" class="menu">
-      <li><a href="#!AMO/editors/">Editors dashboard</a></li>
+      <li><a href="#!AMO/reviewers/">Editors dashboard</a></li>
       <li class="separator"></li>
-      <li><a href="#!AMO/editors/queue/new">New queue</a></li>
-      <li><a href="#!AMO/editors/queue/updates">Updates queue</a></li>
-      <li><a href="#!AMO/editors/queue/auto_approved">Auto approved queue</a></li>
-      <li><a href="#!AMO/editors/queue/reviews">Moderated reviews queue</a></li>
+      <li><a href="#!AMO/reviewers/queue/new">New queue</a></li>
+      <li><a href="#!AMO/reviewers/queue/updates">Updates queue</a></li>
+      <li><a href="#!AMO/reviewers/queue/auto_approved">Auto approved queue</a></li>
+      <li><a href="#!AMO/reviewers/queue/reviews">Moderated reviews queue</a></li>
       <!-- 
       <li class="separator"></li>
       <li><a href="#refreshcount">Refresh queue badge</a></li>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "AMO Review Helper",
   "short_name": "AMO Helper",
-  "version": "7.0.0",
+  "version": "7.0.1",
 
   "applications": {
     "gecko": {
@@ -119,17 +119,17 @@
       "run_at": "document_end"
     },{
       "matches": [
-        "https://reviewers.addons.mozilla.org/*/editors/review/*",
-        "https://reviewers.addons.mozilla.org/*/editors/review-listed/*",
-        "https://reviewers.addons.mozilla.org/*/editors/review-unlisted/*",
+        "https://reviewers.addons.mozilla.org/*/reviewers/review/*",
+        "https://reviewers.addons.mozilla.org/*/reviewers/review-listed/*",
+        "https://reviewers.addons.mozilla.org/*/reviewers/review-unlisted/*",
 
-        "https://reviewers.addons.allizom.org/*/editors/review/*",
-        "https://reviewers.addons.allizom.org/*/editors/review-listed/*",
-        "https://reviewers.addons.allizom.org/*/editors/review-unlisted/*",
+        "https://reviewers.addons.allizom.org/*/reviewers/review/*",
+        "https://reviewers.addons.allizom.org/*/reviewers/review-listed/*",
+        "https://reviewers.addons.allizom.org/*/reviewers/review-unlisted/*",
 
-        "https://reviewers.addons-dev.allizom.org/*/editors/review/*",
-        "https://reviewers.addons-dev.allizom.org/*/editors/review-listed/*",
-        "https://reviewers.addons-dev.allizom.org/*/editors/review-unlisted/*"
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/review/*",
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/review-listed/*",
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/review-unlisted/*"
       ],
       "js": [
         "libs/diff.min.js",
@@ -168,14 +168,14 @@
       "run_at": "document_end"
     },{
       "matches": [
-        "https://reviewers.addons.mozilla.org/*/editors/queue/reviews",
-        "https://reviewers.addons.mozilla.org/*/editors/queue/reviews",
+        "https://reviewers.addons.mozilla.org/*/reviewers/queue/reviews",
+        "https://reviewers.addons.mozilla.org/*/reviewers/queue/reviews",
 
-        "https://reviewers.addons.allizom.org/*/editors/queue/reviews",
-        "https://reviewers.addons.allizom.org/*/editors/queue/reviews",
+        "https://reviewers.addons.allizom.org/*/reviewers/queue/reviews",
+        "https://reviewers.addons.allizom.org/*/reviewers/queue/reviews",
 
-        "https://reviewers.addons-dev.allizom.org/*/editors/queue/reviews",
-        "https://reviewers.addons-dev.allizom.org/*/editors/queue/reviews"
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/queue/reviews",
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/queue/reviews"
       ],
       "js": [
         "common/constants.js",
@@ -186,9 +186,9 @@
       "run_at": "document_end"
     },{
       "matches": [
-        "https://reviewers.addons.mozilla.org/*/editors/queue/*",
-        "https://reviewers.addons.allizom.org/*/editors/queue/*",
-        "https://reviewers.addons-dev.allizom.org/*/editors/queue/*"
+        "https://reviewers.addons.mozilla.org/*/reviewers/queue/*",
+        "https://reviewers.addons.allizom.org/*/reviewers/queue/*",
+        "https://reviewers.addons-dev.allizom.org/*/reviewers/queue/*"
       ],
       "js": [
         "libs/moment.min.js",


### PR DESCRIPTION
Simple find and replace of all /editors/ urls to /reviewers/ because of https://github.com/mozilla/addons-server/pull/6988